### PR TITLE
4sep playback enhance

### DIFF
--- a/main/templates/home.html
+++ b/main/templates/home.html
@@ -50,58 +50,24 @@ const WAVE_URL = `/wave`;
 let   POLL_MS  = 1000;
 const CIRCLE_RADIUS_M = 1000;
 
-/* ---------------- Legend colors ---------------- */
-const LEVELS = [100, 300, 500, 800, 1200];
-const COLORS5 = [
-  {name:'Red',    hex:'#e31a1c'},
-  {name:'Green',  hex:'#33a02c'},
-  {name:'Blue',   hex:'#1f78b4'},
-  {name:'Yellow', hex:'#ffcc00'},
-  {name:'Orange', hex:'#ff7f00'}
-];
+/* ---------------- Unified color scale (10 bins @ 30k–40k) ---------------- */
+const RMS_MIN = 30000, RMS_MAX = 40000, BINS = 10;
+const RED_OOR = '#ff1744';
+const SCALE10 = ['#440154','#482878','#3e4a89','#31688e','#26828e','#1f9e89','#35b779','#6ece58','#b5de2b','#fde725'];
+
+function colorForRMS_10(rms){
+  if (!Number.isFinite(rms)) return RED_OOR;
+  if (rms < RMS_MIN || rms > RMS_MAX) return RED_OOR;
+  const t = (rms - RMS_MIN) / (RMS_MAX - RMS_MIN);
+  const idx = Math.min(BINS - 1, Math.max(0, Math.floor(t * BINS)));
+  return SCALE10[idx];
+}
+
+// keep the same call sites; no station offset anymore
+function colorForStationRMS(id, rms){ return { hex: colorForRMS_10(rms), name: '' }; }
 
 /* ---------------- Helpers ---------------- */
-const stationOrder = {}; let stationSeq = 0;
 const isNum = (v) => Number.isFinite(v) && !Number.isNaN(v);
-function getStationOffset(id){ if(!(id in stationOrder)) stationOrder[id]=stationSeq++; return stationOrder[id]%COLORS5.length; }
-function rmsLevelIndex(rms){ let b=0,d=Infinity; for(let i=0;i<LEVELS.length;i++){const di=Math.abs((rms||0)-LEVELS[i]); if(di<d){b=i; d=di}} return b; }
-function colorForStationRMS(id,rms){ const idx=rmsLevelIndex(rms); const off=getStationOffset(id); return COLORS5[(idx+off)%COLORS5.length]; }
-
-/* meters -> lat/lon offset */
-function offsetLatLng(lat, lon, dx_m, dy_m){
-  const R = 6378137; // m
-  const dLat = (dy_m / R) * 180 / Math.PI;
-  const dLon = (dx_m / (R * Math.cos(lat * Math.PI / 180))) * 180 / Math.PI;
-  return [lat + dLat, lon + dLon];
-}
-
-/* compute de-overlap positions for stations sharing same lat/lon */
-function computeRenderPositions(stations){
-  const key = (s)=> `${s.lat.toFixed(6)},${s.lon.toFixed(6)}`;
-  const groups = new Map();
-  stations.forEach(s=>{
-    const k = key(s);
-    if(!groups.has(k)) groups.set(k, []);
-    groups.get(k).push(s.id);
-  });
-  const renderPos = new Map();
-  for (const [k, ids] of groups.entries()){
-    const [lat, lon] = k.split(',').map(Number);
-    const n = ids.length;
-    if (n === 1){
-      renderPos.set(ids[0], [lat, lon]);
-      continue;
-    }
-    const Rm = 140; // ring radius in meters for separation
-    for (let i=0;i<n;i++){
-      const ang = (2*Math.PI*i)/n;
-      const dx = Rm * Math.cos(ang);
-      const dy = Rm * Math.sin(ang);
-      renderPos.set(ids[i], offsetLatLng(lat, lon, dx, dy));
-    }
-  }
-  return renderPos;
-}
 
 /* ---------------- Map ---------------- */
 const map = L.map('map', { preferCanvas: true });
@@ -153,23 +119,25 @@ function upsertMarker(s, lat, lon){
 /* ---------------- Overlays ---------------- */
 (function renderLegend(){
   const box = document.getElementById('legend');
-  let html = '<h4>RMS → Color (fixed ×5)</h4>';
-  for (let i=0;i<COLORS5.length;i++){
-    html += `<div class="row"><span class="sw" style="background:${COLORS5[i].hex}"></span><span>${COLORS5[i].name} → ~${LEVELS[i]}</span></div>`;
+  let html = '<h4>RMS 30,000 → 40,000 (10 bins)</h4>';
+  for (let i=0;i<SCALE10.length;i++){
+    const lo = Math.round(RMS_MIN + i*(RMS_MAX-RMS_MIN)/BINS);
+    const hi = Math.round(RMS_MIN + (i+1)*(RMS_MAX-RMS_MIN)/BINS);
+    html += `<div class="row"><span class="sw" style="background:${SCALE10[i]}"></span><span>${lo}–${hi}</span></div>`;
   }
-  html += '<div class="note">Each station is offset by one color and cycles. Coincident stations are auto-separated.</div>';
+  html += `<div class="note"><b style="color:${RED_OOR}">Red</b> = outside ${RMS_MIN}–${RMS_MAX}</div>`;
   box.innerHTML = html;
 })();
 
 function updateBadges(stations){
   const root = document.getElementById('badges'); root.innerHTML = '';
   for (const s of stations){
-    const col = colorForStationRMS(s.id, s.rms);
+    const col = colorForStationRMS(s.id, s.rms).hex;
     const span = document.createElement('span');
     span.className = 'badge';
-    span.style.borderColor = col.hex;
-    span.style.color = col.hex;
-    span.textContent = `${s.id}: RMS ${s.rms != null ? s.rms.toFixed(1) : '—'} (${col.name})`;
+    span.style.borderColor = col;
+    span.style.color = col;
+    span.textContent = `${s.id}: RMS ${s.rms != null ? s.rms.toFixed(1) : '—'}`;
     span.onclick = () => loadWaveform(s.id);
     root.appendChild(span);
   }
@@ -192,11 +160,8 @@ async function poll(){
     stations = stations.map(s => ({...s, lat:Number(s.lat), lon:Number(s.lon)}))
                        .filter(s => isNum(s.lat) && isNum(s.lon));
 
-    const renderPos = computeRenderPositions(stations);
-
     for (const s of stations){
-      const pos = renderPos.get(s.id) || [s.lat, s.lon];
-      upsertMarker(s, pos[0], pos[1]);
+      upsertMarker(s, s.lat, s.lon);
     }
 
     // remove stale
@@ -209,7 +174,7 @@ async function poll(){
     });
 
     if (!firstFit && stations.length){
-      const bounds = L.latLngBounds(stations.map(s => renderPos.get(s.id) || [s.lat, s.lon]));
+      const bounds = L.latLngBounds(stations.map(s => [s.lat, s.lon]));
       if (bounds.isValid()) map.fitBounds(bounds, {padding:[30,30], maxZoom: 12});
       firstFit = true;
       loadWaveform(stations[0].id);

--- a/main/templates/playback.html
+++ b/main/templates/playback.html
@@ -37,9 +37,11 @@
     <div id="mapWrap" class="container-main">
       <div id="seismicMap"></div>
       <div id="badges" class="overlay dark"></div>
+      <div id="legend" class="overlay dark"></div>
+      <div id="queryResult" class="overlay dark" style="right:10px; top:10px; left:auto;"></div>
     </div>
 
-    <!-- CONTROLS: under the map, above the waveform -->
+    <!-- CONTROLS -->
     <div id="controls">
       <div class="controls-row">
         <button id="playBtn" type="button" class="btn" disabled>▶ Play</button>
@@ -47,6 +49,7 @@
         <select id="stationSelect" class="station-select" hidden></select>
         <span id="sliderLabel" class="text-xs text-muted"></span>
       </div>
+
       <div class="slider-container">
         <label for="playbackSlider" class="slider-caption">Timeline:</label>
         <input type="range" id="playbackSlider" class="slider" min="0" max="0" value="0" disabled>
@@ -59,211 +62,207 @@
     </div>
   </div>
 
-  <!-- SINGLE script tag (the duplicate one caused the bug) -->
-  <script>
-  /* ---------- State ---------- */
-  let uploadedFilenames = [];
-  let sliderMin = 0, sliderMax = 0;
-  let sliderStartISO = null, sliderEndISO = null;
-  let selectedStationId = null;
-  let playTimer = null;
+<script>
+let RMS_MIN = 30000, RMS_MAX = 40000;
+const BINS = 10;
+const RED_OOR = '#ff1744';
+const SCALE10 = ['#440154','#482878','#3e4a89','#31688e','#26828e','#1f9e89','#35b779','#6ece58','#b5de2b','#fde725'];
 
-  const slider = document.getElementById('playbackSlider');
-  const sliderLabel = document.getElementById('sliderLabel');
-  const playBtn = document.getElementById('playBtn');
-  const pauseBtn = document.getElementById('pauseBtn');
-  const stationSelect = document.getElementById('stationSelect');
-
-  /* ---------- Upload ---------- */
-  document.getElementById('uploadForm').addEventListener('submit', async (e) => {
-    e.preventDefault();                                 // keep page here
-    const filesInput = document.getElementById('seedlink_files');
-    const formData = new FormData();
-    for (let i = 0; i < filesInput.files.length; i++) formData.append('seedlink_file', filesInput.files[i]);
-
-    const res = await fetch('/playback', { method: 'POST', body: formData });
-    const data = await res.json().catch(()=>({}));
-    if (data.status !== 'uploaded') { alert('Upload failed'); return; }
-
-    uploadedFilenames = Array.isArray(data.filenames) ? data.filenames : [data.filename];
-
-    await initTimeline();         // enables slider
-    await refreshMap();           // sets first station + badges
-    await drawWave();             // draws first frame
-
-    setPlayingState(false);       // Play enabled, Pause disabled
-  });
-
-  /* ---------- Timeline ---------- */
-  async function initTimeline() {
-    const res = await fetch(`/playback_timeline/${uploadedFilenames.join(',')}`, { cache:'no-store' });
-    const t = await res.json();
-    sliderStartISO = t.start_iso;
-    sliderEndISO   = t.end_iso;
-    sliderMin = 0;
-    sliderMax = Math.max(0, (t.steps ?? 1) - 1);
-
-    slider.min = sliderMin;
-    slider.max = sliderMax;
-    slider.value = sliderMin;
-    slider.disabled = false;
-
-    updateSliderLabel();
+function setColorRange(minV, maxV){
+  if (Number.isFinite(minV) && Number.isFinite(maxV) && minV < maxV) {
+    RMS_MIN = minV; RMS_MAX = maxV;
+    renderLegend(); refreshMap();
   }
+}
+function colorForRMS_10(rms){
+  if (!Number.isFinite(rms)) return RED_OOR;
+  if (rms < RMS_MIN || rms > RMS_MAX) return RED_OOR;
+  const t = (rms - RMS_MIN) / (RMS_MAX - RMS_MIN);
+  const idx = Math.min(BINS - 1, Math.max(0, Math.floor(t * BINS)));
+  return SCALE10[idx];
+}
+function fmtAWST(x){
+  const d = (x instanceof Date) ? x : new Date(x);
+  const parts = new Intl.DateTimeFormat("en-AU", {
+    timeZone: "Australia/Perth",
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit",
+    hour12: false
+  }).formatToParts(d).reduce((acc, p) => { acc[p.type] = p.value; return acc; }, {});
+  return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}:${parts.second} AWST`;
+}
 
-  slider.addEventListener('input', async () => {
-    updateSliderLabel();
-    await refreshMap();
-    await drawWave();
-  });
+let uploadedFilenames=[], sliderMin=0, sliderMax=0, sliderStartISO=null, sliderEndISO=null,
+    selectedStationId=null, playTimer=null;
+const slider=document.getElementById('playbackSlider'),
+      sliderLabel=document.getElementById('sliderLabel'),
+      playBtn=document.getElementById('playBtn'),
+      pauseBtn=document.getElementById('pauseBtn'),
+      stationSelect=document.getElementById('stationSelect');
 
-  function updateSliderLabel() {
-    if (!sliderStartISO || !sliderEndISO) { sliderLabel.textContent = ''; return; }
-    const curISO = getSliderISO(Number(slider.value));
-    sliderLabel.textContent =
-      `${new Date(sliderStartISO).toLocaleString()} — ${new Date(sliderEndISO).toLocaleString()} | Current: ${new Date(curISO).toLocaleString()}`;
-  }
+document.getElementById('uploadForm').addEventListener('submit', async (e)=>{
+  e.preventDefault();
+  const filesInput=document.getElementById('seedlink_files');
+  const formData=new FormData();
+  for (let i=0;i<filesInput.files.length;i++) formData.append('seedlink_file',filesInput.files[i]);
+  const res=await fetch('/playback',{method:'POST',body:formData});
+  const data=await res.json().catch(()=>({}));
+  if (data.status!=='uploaded'){ alert('Upload failed'); return; }
 
-  function getSliderISO(val) {
-    const start = new Date(sliderStartISO).getTime();
-    const end   = new Date(sliderEndISO).getTime();
-    const step  = (end - start) / (sliderMax - sliderMin || 1);
-    return new Date(start + (val - sliderMin) * step).toISOString();
-  }
+  uploadedFilenames=Array.isArray(data.filenames)?data.filenames:[data.filename];
+  await initTimeline();
 
-  /* ---------- Map ---------- */
-  let map = null;
-  let markers = [];
+  try {
+    const stats=await fetchJSON(`/playback_stats/${uploadedFilenames.join(',')}`);
+    const vmin=stats?.min?.value, vmax=stats?.max?.value;
+    const out=document.getElementById('queryResult');
+    if (Number.isFinite(vmin)&&Number.isFinite(vmax)&&vmax>vmin){
+      out.innerHTML=`<b>Detected Hour RMS Range</b><br/>
+        Min: ${vmin.toFixed(1)} @ <code>${stats.min.id}</code> (${fmtAWST(stats.min.iso)})<br/>
+        Max: ${vmax.toFixed(1)} @ <code>${stats.max.id}</code> (${fmtAWST(stats.max.iso)})`;
+      const ok=window.confirm(`Detected hour min/max RMS:\n\nmin = ${vmin.toFixed(1)}\nmax = ${vmax.toFixed(1)}\n\nUse this as the 10-bin color range?`);
+      if (ok) setColorRange(vmin, vmax);
+    } else { out.textContent='Could not detect min/max RMS'; }
+  } catch { document.getElementById('queryResult').textContent='Stats error'; }
 
-  function ensureMap() {
-    if (map) return;
-    map = L.map('seismicMap', { preferCanvas: true }).setView([-31.35, 115.92], 10);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                { maxZoom: 18, attribution: '© OpenStreetMap' }).addTo(map);
-  }
+  await refreshMap(); await drawWave(); setPlayingState(false);
+});
 
-  function colorForRMS(rms){
-    const LEVELS=[100,300,500,800,1200], COLORS=['#e31a1c','#33a02c','#1f78b4','#ffcc00','#ff7f00'];
-    let idx=0,d=Infinity; for (let i=0;i<LEVELS.length;i++){ const di=Math.abs((rms||0)-LEVELS[i]); if(di<d){d=di;idx=i;} }
-    return COLORS[idx];
-  }
+async function initTimeline(){
+  const res=await fetch(`/playback_timeline/${uploadedFilenames.join(',')}`,{cache:'no-store'});
+  const t=await res.json();
+  sliderStartISO=t.start_iso; sliderEndISO=t.end_iso;
+  sliderMin=0; sliderMax=Math.max(0,(t.steps??1)-1);
+  slider.min=sliderMin; slider.max=sliderMax; slider.value=sliderMin;
+  slider.disabled=false; updateSliderLabel();
+}
+slider.addEventListener('input', async ()=>{
+  updateSliderLabel(); await refreshMap(); await drawWave();
+});
 
-  function populateStationSelect(stations) {
-    if (!stations || stations.length <= 1) {
-      stationSelect.hidden = true; stationSelect.replaceChildren(); return;
-    }
-    stationSelect.hidden = false;
-    stationSelect.replaceChildren(...stations.map(st => {
-      const opt = document.createElement('option'); opt.value = st.id; opt.textContent = st.id; return opt;
-    }));
-    if (!selectedStationId) selectedStationId = stations[0].id;
-    stationSelect.value = selectedStationId;
-  }
+function updateSliderLabel(){
+  if (!sliderStartISO||!sliderEndISO){ sliderLabel.textContent=''; return; }
+  const curISO=getSliderISO(Number(slider.value));
+  sliderLabel.textContent=`${fmtAWST(sliderStartISO)} — ${fmtAWST(sliderEndISO)} | Current: ${fmtAWST(curISO)}`;
+}
+function getSliderISO(val){
+  const start=new Date(sliderStartISO).getTime();
+  const end=new Date(sliderEndISO).getTime();
+  const step=(end-start)/(sliderMax-sliderMin||1);
+  return new Date(start+(val-sliderMin)*step).toISOString();
+}
 
-  async function refreshMap() {
-    if (!uploadedFilenames.length) return;
-    ensureMap();
+let map=null, markers=[];
+function ensureMap(){ if(map)return;
+  map=L.map('seismicMap',{preferCanvas:true}).setView([-31.35,115.92],10);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    {maxZoom:18, attribution:'© OpenStreetMap'}).addTo(map);
+}
+function populateStationSelect(stations){
+  if(!stations||stations.length<=1){ stationSelect.hidden=true; stationSelect.replaceChildren(); return; }
+  stationSelect.hidden=false;
+  stationSelect.replaceChildren(...stations.map(st=>{
+    const opt=document.createElement('option'); opt.value=st.id; opt.textContent=st.id; return opt;
+  }));
+  if(!selectedStationId) selectedStationId=stations[0].id;
+  stationSelect.value=selectedStationId;
+}
 
-    // clear previous markers
-    markers.forEach(m => map.removeLayer(m)); markers = [];
+async function refreshMap(){
+  if(!uploadedFilenames.length)return;
+  ensureMap(); markers.forEach(m=>map.removeLayer(m)); markers=[];
+  const step=Number(slider.value);
+  const data=await fetchJSON(`/playback_data/${uploadedFilenames.join(',')}/${step}`);
+  const stations=Array.isArray(data.stations)?data.stations:[];
+  if(!selectedStationId&&stations.length)selectedStationId=stations[0].id;
+  populateStationSelect(stations);
 
-    const step = Number(slider.value);
-    const data = await fetchJSON(`/playback_data/${uploadedFilenames.join(',')}/${step}`);
-    const stations = Array.isArray(data.stations) ? data.stations : [];
-
-    if (!selectedStationId && stations.length) selectedStationId = stations[0].id;
-    populateStationSelect(stations);
-
-    stations.forEach(st => {
-      const col = colorForRMS(st.rms);
-      const m = L.circleMarker([st.lat, st.lon], { radius: 10, color: col, fillColor: col, fillOpacity: 0.85 })
-        .addTo(map).bindPopup(`<b>${st.id}</b><br>RMS: ${st.rms.toFixed(2)}`);
-      m.on('click', async () => { selectedStationId = st.id; stationSelect.value = st.id; await drawWave(); });
-      markers.push(m);
-    });
-
-    // badges
-    const badges = document.getElementById('badges');
-    badges.innerHTML = stations.map(st =>
-      `<span class="chip" style="border-color:${colorForRMS(st.rms)};color:${colorForRMS(st.rms)}">${st.id}: <b>${st.rms.toFixed(2)}</b></span>`
-    ).join(' ');
-  }
-
-  stationSelect.addEventListener('change', async () => {
-    selectedStationId = stationSelect.value; await drawWave();
-  });
-
-  /* ---------- Waveform ---------- */
-  async function drawWave() {
-    if (!uploadedFilenames.length || !selectedStationId) return;
-
-    const step = Number(slider.value);
-    const url = `/playback_wave/${uploadedFilenames.join(',')}/${step}/${encodeURIComponent(selectedStationId)}`;
-
-    const w = await fetchJSON(url);
-    const fs = Number(w.fs || 0);
-    const values = Array.isArray(w.values) ? w.values : [];
-    const t0 = w.t0_iso ? new Date(w.t0_iso) : null;
-
-    if (!values.length) {
-      Plotly.react('wave', [], {
-        paper_bgcolor:'#111', plot_bgcolor:'#111',
-        margin:{l:50,r:10,t:10,b:40}, xaxis:{gridcolor:'#333'}, yaxis:{gridcolor:'#333'}
-      });
-      return;
-    }
-    const dt = fs > 0 ? 1.0 / fs : 0.004;
-    const xs = t0 ? values.map((_, i) => new Date(t0.getTime() + i * dt * 1000)) : values.map((_, i) => i);
-
-    Plotly.react('wave',
-      [{ x: xs, y: values, type: 'scatter', mode: 'lines', name: selectedStationId }],
-      {
-        paper_bgcolor:'#111', plot_bgcolor:'#111', font:{color:'#eaeaea'},
-        margin:{l:50,r:10,t:10,b:40},
-        xaxis:{title:'time', gridcolor:'#333'},
-        yaxis:{title:'amplitude', gridcolor:'#333'},
-        uirevision:'keep'
-      },
-      { responsive:true }
+  stations.forEach(st=>{
+    const col=colorForRMS_10(st.rms);
+    const m=L.circle([st.lat,st.lon],{
+      radius:1000,color:'#222',weight:2,fillColor:col,fillOpacity:0.75
+    }).addTo(map).bindPopup(
+      `<b>${st.id}</b><br>RMS: ${st.rms.toFixed(1)}<br>${fmtAWST(sliderStartISO)}`
     );
-  }
+    m.on('click', async()=>{selectedStationId=st.id;stationSelect.value=st.id;await drawWave();});
+    markers.push(m);
+  });
 
-  /* ---------- Play / Pause (1 step/second) ---------- */
-  function setPlayingState(isPlaying) {
-    playBtn.disabled  = isPlaying || slider.disabled;
-    pauseBtn.disabled = !isPlaying || slider.disabled;
-  }
+  const badges=document.getElementById('badges');
+  badges.innerHTML=stations.map(st=>
+    `<span class="chip" style="border-color:${colorForRMS_10(st.rms)};color:${colorForRMS_10(st.rms)}">
+      ${st.id}: <b>${st.rms.toFixed(1)}</b></span>`
+  ).join(' ');
+  renderLegend();
+}
 
-  async function stepOnce() {
-    const next = Math.min(Number(slider.max), Number(slider.value) + 1);
-    slider.value = next;
-    updateSliderLabel();
-    await refreshMap();
-    await drawWave();
-    if (next >= Number(slider.max)) stopPlaying();
-  }
+stationSelect.addEventListener('change', async()=>{
+  selectedStationId=stationSelect.value; await drawWave();
+});
 
-  function startPlaying(intervalMs = 1000) { // 1 Hz
-    if (playTimer || slider.disabled) return;
-    setPlayingState(true);
-    playTimer = setInterval(stepOnce, intervalMs);
+function renderLegend(){
+  const box=document.getElementById('legend');
+  let html=`<h4>RMS ${Math.round(RMS_MIN)} → ${Math.round(RMS_MAX)} (10 bins)</h4>`;
+  for(let i=0;i<SCALE10.length;i++){
+    const lo=RMS_MIN+i*(RMS_MAX-RMS_MIN)/BINS;
+    const hi=RMS_MIN+(i+1)*(RMS_MAX-RMS_MIN)/BINS;
+    html+=`<div class="row"><span class="sw" style="background:${SCALE10[i]}"></span>
+      <span>${lo.toFixed(1)}–${hi.toFixed(1)}</span></div>`;
   }
+  html+=`<div class="note"><b style="color:${RED_OOR}">Red</b> = outside ${RMS_MIN.toFixed(1)}–${RMS_MAX.toFixed(1)}</div>`;
+  box.innerHTML=html;
+}
 
-  function stopPlaying() {
-    if (playTimer) clearInterval(playTimer);
-    playTimer = null;
-    setPlayingState(false);
+async function drawWave(){
+  if(!uploadedFilenames.length||!selectedStationId)return;
+  const step=Number(slider.value);
+  const url=`/playback_wave/${uploadedFilenames.join(',')}/${step}/${encodeURIComponent(selectedStationId)}`;
+  const w=await fetchJSON(url);
+  const fs=Number(w.fs||0);
+  const values=Array.isArray(w.values)?w.values:[];
+  const t0=w.t0_iso?new Date(w.t0_iso):null;
+  if(!values.length){
+    Plotly.react('wave',[],{paper_bgcolor:'#111',plot_bgcolor:'#111',
+      margin:{l:50,r:10,t:10,b:40},xaxis:{gridcolor:'#333'},yaxis:{gridcolor:'#333'}});
+    return;
   }
+  const dt=fs>0?1.0/fs:0.004;
+  const xs=t0?values.map((_,i)=>new Date(t0.getTime()+i*dt*1000)):values.map((_,i)=>i);
+  Plotly.react('wave',[{x:xs,y:values,type:'scatter',mode:'lines',name:selectedStationId}],
+    {paper_bgcolor:'#111',plot_bgcolor:'#111',font:{color:'#eaeaea'},
+      margin:{l:50,r:10,t:10,b:40},xaxis:{title:'time',gridcolor:'#333'},
+      yaxis:{title:'amplitude',gridcolor:'#333'},uirevision:'keep'},
+    {responsive:true});
+}
 
-  playBtn.addEventListener('click', () => startPlaying(1000));
-  pauseBtn.addEventListener('click', stopPlaying);
+function setPlayingState(isPlaying){
+  playBtn.disabled=isPlaying||slider.disabled;
+  pauseBtn.disabled=!isPlaying||slider.disabled;
+}
+async function stepOnce(){
+  const next=Math.min(Number(slider.max),Number(slider.value)+1);
+  slider.value=next; updateSliderLabel(); await refreshMap(); await drawWave();
+  if(next>=Number(slider.max)) stopPlaying();
+}
+function startPlaying(intervalMs=1000){
+  if(playTimer||slider.disabled) return;
+  setPlayingState(true); playTimer=setInterval(stepOnce,intervalMs);
+}
+function stopPlaying(){
+  if(playTimer) clearInterval(playTimer);
+  playTimer=null; setPlayingState(false);
+}
+playBtn.addEventListener('click',()=>startPlaying(1000));
+pauseBtn.addEventListener('click',stopPlaying);
 
-  /* ---------- Utils ---------- */
-  async function fetchJSON(url){
-    const res = await fetch(url, { cache:'no-store' });
-    if (!res.ok) throw new Error('Request failed');
-    return res.json();
-  }
-  </script>
+async function fetchJSON(url){
+  const res=await fetch(url,{cache:'no-store'});
+  if(!res.ok) throw new Error('Request failed');
+  return res.json();
+}
+</script>
+
+
+
 </body>
 </html>


### PR DESCRIPTION
🔹 playback.html

Uses fixed 1 km circles (same as live).

Both map and waveform use a 10-bin color ramp (Viridis) with bright red for out-of-range.

After upload, the server computes hour-wide min/max RMS → shown top-right; user can accept to re-scale bins.

Times are displayed as AWST (YYYY-MM-DD HH:mm:ss AWST) consistently in slider, overlay, popups.

🔹 home.html (live)

Also switched to the same 10-bin color ramp (no station offsets anymore).

Circles are already 1 km radius.

Legend matches playback, but live data just stays fixed 30k–40k since no “whole hour” is known.

🔹 app.py

Added /playback_stats endpoint: computes per-hour min/max RMS server-side with ObsPy + NumPy.

/playback_timeline still defines slider start/end from MiniSEED metadata.

Currently outputs UTC ISO strings (frontend converts to AWST) ##NOT CORRECT NEEDS FIX